### PR TITLE
Add belief button with local counter

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -155,3 +155,18 @@
 .animation-delay-4000 {
   animation-delay: 4s;
 }
+
+@keyframes riseAndFade {
+  from {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  to {
+    opacity: 0;
+    transform: translateY(-20px);
+  }
+}
+
+.animate-rise-fade {
+  animation: riseAndFade 0.8s ease-out forwards;
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,10 +2,26 @@
 import { useLanguage } from "@/contexts/language-context";
 import { LanguageToggle } from "@/components/language-toggle";
 import { Logo } from "@/components/logo";
-import { FC } from "react";
+import { Button } from "@/components/ui/button";
+import { FC, useState, useEffect } from "react";
 
 const Home: FC = () => {
   const { t, language } = useLanguage();
+  const [count, setCount] = useState(0);
+  const [showPlusOne, setShowPlusOne] = useState(false);
+
+  useEffect(() => {
+    const saved = Number(localStorage.getItem("belief-count") || 0);
+    if (!isNaN(saved)) setCount(saved);
+  }, []);
+
+  const handleBelieveClick = () => {
+    const newCount = count + 1;
+    setCount(newCount);
+    localStorage.setItem("belief-count", String(newCount));
+    setShowPlusOne(true);
+    setTimeout(() => setShowPlusOne(false), 800);
+  };
 
   return (
     <main className="min-h-screen bg-gradient-to-b from-sky-50 via-white to-sky-50 flex flex-col items-center justify-center px-4 py-8 md:py-16 text-center relative overflow-hidden">
@@ -96,6 +112,20 @@ const Home: FC = () => {
             >
               {t("joinDescription")}
             </p>
+          </div>
+          <div className="pt-4 flex justify-center">
+            <div className="relative">
+              <Button onClick={handleBelieveClick}>
+                {language === "zh"
+                  ? `信仰我们 (${count})`
+                  : `Believe in Us (${count})`}
+              </Button>
+              {showPlusOne && (
+                <span className="absolute -top-4 left-1/2 -translate-x-1/2 text-red-500 pointer-events-none animate-rise-fade">
+                  +1
+                </span>
+              )}
+            </div>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- add rise-and-fade animation
- implement `信仰我们` (Believe in Us) button that stores count locally

## Testing
- `pnpm install`
- `npm run lint` *(fails: interactive/command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fcae08114832296b4a74518041123